### PR TITLE
Port to new python-docker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Registers running instances with avahi, for easy local usage of ran containers.
 Requirements:
 
 * python3
-* python-docker (>= 1.0.0)
+* python-docker (>= 2.4.2)
 * avahi-utils
 
 Installation


### PR DESCRIPTION
Hi @fsateler, I've updated avahi-docker to support the python-docker 2.4.2 API.